### PR TITLE
Release CLI 1.19.0

### DIFF
--- a/decodable.rb
+++ b/decodable.rb
@@ -9,7 +9,7 @@ class Decodable < Formula
   on_macos do
     if Hardware::CPU.intel?
       url "https://releases.decodable.co/decodable-cli/darwin/amd64/decodable-cli-darwin-amd64-1.18.0.tar.gz"
-      sha256 "20793ec2caba941b3a28207a5dc1fc27696f07a1392f2d781fa875d81a941afd"
+      sha256 "98108244653e4103559154392ef2668029f388c7665164257d605d9e52786e18"
 
       def install
         bin.install "bin/decodable"
@@ -17,7 +17,7 @@ class Decodable < Formula
     end
     if Hardware::CPU.arm?
       url "https://releases.decodable.co/decodable-cli/darwin/arm64/decodable-cli-darwin-arm64-1.18.0.tar.gz"
-      sha256 "943dc4d701c9790f00b9e032f6cea6b21361490d39ccc88b1a6f5da969c92e93"
+      sha256 "b458b3ee3ee3a2a6f27315902f664d67b1d1fd4889a4479b59cee17b5287df43"
 
       def install
         bin.install "bin/decodable"


### PR DESCRIPTION
Release CLI v 1.19.0 (notably with support for MSC connections in the declarative CLI commands).