### PR TITLE
DE-7497: Release CLI v1.20.0

### DIFF
--- a/decodable.rb
+++ b/decodable.rb
@@ -4,20 +4,20 @@
 class Decodable < Formula
   desc "Manage Decodable resources from the CLI"
   homepage "https://www.decodable.co/"
-  version "1.18.0"
+  version "1.20.0"
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://releases.decodable.co/decodable-cli/darwin/amd64/decodable-cli-darwin-amd64-1.18.0.tar.gz"
-      sha256 "98108244653e4103559154392ef2668029f388c7665164257d605d9e52786e18"
+      url "https://releases.decodable.co/decodable-cli/darwin/amd64/decodable-cli-darwin-amd64-1.20.0.tar.gz"
+      sha256 "2badb1b52987debafde888bdfcf5942fa98e7add4ba2a0a28acadbddafb53a00"
 
       def install
         bin.install "bin/decodable"
       end
     end
     if Hardware::CPU.arm?
-      url "https://releases.decodable.co/decodable-cli/darwin/arm64/decodable-cli-darwin-arm64-1.18.0.tar.gz"
-      sha256 "b458b3ee3ee3a2a6f27315902f664d67b1d1fd4889a4479b59cee17b5287df43"
+      url "https://releases.decodable.co/decodable-cli/darwin/arm64/decodable-cli-darwin-arm64-1.20.0.tar.gz"
+      sha256 "cbd4a424ab6c5b8249b03bfa3050fb88e5a132b5662b4ef6e52af97fc0991449"
 
       def install
         bin.install "bin/decodable"


### PR DESCRIPTION
DE-7497: Release CLI v1.20.0

SHAs Per:
```
2badb1b52987debafde888bdfcf5942fa98e7add4ba2a0a28acadbddafb53a00  decodable-cli-darwin-amd64-1.20.0.tar.gz
cbd4a424ab6c5b8249b03bfa3050fb88e5a132b5662b4ef6e52af97fc0991449  decodable-cli-darwin-arm64-1.20.0.tar.gz
```