### PR TITLE
DE-8440: Homebrew: Upgrade CLI to version 1.20.3

### DIFF
--- a/decodable.rb
+++ b/decodable.rb
@@ -4,20 +4,20 @@
 class Decodable < Formula
   desc "Manage Decodable resources from the CLI"
   homepage "https://www.decodable.co/"
-  version "1.20.1"
+  version "1.20.3"
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://releases.decodable.co/decodable-cli/darwin/amd64/decodable-cli-darwin-amd64-1.20.1.tar.gz"
-      sha256 "5ca3c2e2b7e66c0e9a0f23ec68985d34092f3de1393914c534b7e7b18cdbc95c"
+      url "https://releases.decodable.co/decodable-cli/darwin/amd64/decodable-cli-darwin-amd64-1.20.3.tar.gz"
+      sha256 "205dab70db4c9cda3ec74073cec5001ef198a42fbb580af0c64f21cd352f7f5a"
 
       def install
         bin.install "bin/decodable"
       end
     end
     if Hardware::CPU.arm?
-      url "https://releases.decodable.co/decodable-cli/darwin/arm64/decodable-cli-darwin-arm64-1.20.1.tar.gz"
-      sha256 "ddd37127589a55141b315e297d00a2d49e3ae2a65223902a46a172434e29a8e5"
+      url "https://releases.decodable.co/decodable-cli/darwin/arm64/decodable-cli-darwin-arm64-1.20.3.tar.gz"
+      sha256 "28594842bb39c8341abf9737f277a879dab11b918839082058f98143639e0e9d"
 
       def install
         bin.install "bin/decodable"


### PR DESCRIPTION
https://decodable.atlassian.net/browse/DE-8440

This PR will update our homebrew of decodable cli to v 1.20.3